### PR TITLE
Upgrade to Java 21 and Spring 3.5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,8 @@
         <url/>
     </scm>
     <properties>
+        <java.version>21</java.version>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
     </properties>
     <dependencies>
         <dependency>
@@ -94,9 +96,8 @@
             <version>4.5.0</version>
         </dependency>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-            <version>2.0.1.Final</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -116,7 +117,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.5.3</version>
+                <version>3.5.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/main/java/com/sadad/orca/securitycore/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/sadad/orca/securitycore/exceptions/GlobalExceptionHandler.java
@@ -18,8 +18,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Objects;


### PR DESCRIPTION
## Summary
- Set project to target Java 21 and updated dependency management to Spring Boot 3.5.4.
- Added Spring Boot validation starter and migrated validation imports to `jakarta.validation`.

## Testing
- `mvn -q test` *(fails: Could not transfer artifacts from repo.sadad.co.ir)*

------
https://chatgpt.com/codex/tasks/task_e_689afa44b4d88323a26167b3693717b9